### PR TITLE
Add database support for messages

### DIFF
--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -257,7 +258,7 @@ func play_database() {
 		Path:     "/test",
 		Response: "Zdarova",
 	}
-	err := database.AddStaticEndpoint(endpoint)
+	err := database.AddStaticEndpoint(context.TODO(), endpoint)
 	if err != nil {
 		panic(err)
 	}
@@ -265,7 +266,7 @@ func play_database() {
 		Str("endpoint", endpoint.Path).
 		Str("response", endpoint.Response).
 		Msg("Added")
-	res, _ := database.ListAllStaticEndpointPaths()
+	res, _ := database.ListAllStaticEndpointPaths(context.TODO())
 	zlog.Info().Interface("endpoints", res).Msg("Queried")
 }
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -48,3 +48,4 @@ server:
 
 database:
     inmemory: true
+    cache_size: 100

--- a/configs/production.yaml
+++ b/configs/production.yaml
@@ -48,3 +48,4 @@ server:
 
 database:
     inmemory: true
+    cache_size: 100

--- a/configs/test_database_config.yaml
+++ b/configs/test_database_config.yaml
@@ -15,4 +15,3 @@ logs:
 
 database:
     inmemory: true
-    cache_size: 0

--- a/internal/brokers/mp_task_scheduler.go
+++ b/internal/brokers/mp_task_scheduler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"mock-server/internal/configs"
+	"mock-server/internal/database"
 	"mock-server/internal/util"
 
 	zlog "github.com/rs/zerolog/log"
@@ -133,7 +134,15 @@ func qread(ctx context.Context, task qReadTask) error {
 		return err
 	}
 
-	// write to db
+	for _, msg := range msgs {
+		if err = database.AddTaskMessages(ctx, database.TaskMessage{
+			TaskId:  string(task.getTaskId()),
+			Message: msg,
+		}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -166,7 +175,15 @@ func qwrite(ctx context.Context, task qWriteTask) error {
 		return err
 	}
 
-	// write to db
+	for _, msg := range task.messages() {
+		if err := database.AddTaskMessages(ctx, database.TaskMessage{
+			TaskId:  string(task.getTaskId()),
+			Message: msg,
+		}); err != nil {
+			return err
+		}
+	}
+
 	zlog.Info().Str("task", string(task.getTaskId())).Err(ctx.Err()).Msg("finished")
 	return nil
 }

--- a/internal/brokers/mp_task_scheduler.go
+++ b/internal/brokers/mp_task_scheduler.go
@@ -52,6 +52,7 @@ type mpTaskScheduler struct {
 	errors      chan TaskError
 	ctx         context.Context
 	wg          sync.WaitGroup
+	waitForGet  sync.WaitGroup
 }
 
 func (mps *mpTaskScheduler) Init(ctx context.Context, cfg *configs.MPTaskSchedulerConfig) {
@@ -75,12 +76,18 @@ func (mps *mpTaskScheduler) Start() {
 	zlog.Info().Msg("starting broker task scheduler")
 	for i := uint32(0); i < mps.cfg.R_workers; i += 1 {
 		mps.wg.Add(1)
+		mps.waitForGet.Add(1)
 		go mps.rWorkerRoutine()
 	}
 	for i := uint32(0); i < mps.cfg.W_workers; i += 1 {
 		mps.wg.Add(1)
+		mps.waitForGet.Add(1)
 		go mps.wWorkerRoutine()
 	}
+}
+
+func (mps *mpTaskScheduler) WaitIdle() {
+	mps.waitForGet.Wait()
 }
 
 func (mps *mpTaskScheduler) Errors() <-chan TaskError {
@@ -135,7 +142,7 @@ func qread(ctx context.Context, task qReadTask) error {
 	}
 
 	for _, msg := range msgs {
-		if err = database.AddTaskMessages(ctx, database.TaskMessage{
+		if err = database.AddTaskMessage(context.TODO(), database.TaskMessage{
 			TaskId:  string(task.getTaskId()),
 			Message: msg,
 		}); err != nil {
@@ -148,12 +155,14 @@ func qread(ctx context.Context, task qReadTask) error {
 
 func (mps *mpTaskScheduler) rWorkerRoutine() {
 	for {
+		mps.waitForGet.Done()
 		elem := mps.read_tasks.Get()
 		if elem.IsNone() {
 			zlog.Debug().Msg("r_worker Done")
 			mps.wg.Done()
 			return
 		}
+		mps.waitForGet.Add(1)
 		task := elem.Unwrap()
 		task_ctx, cancel := context.WithTimeout(mps.ctx, mps.cfg.Read_timeout)
 		if err := qread(task_ctx, task); err != nil {
@@ -176,7 +185,7 @@ func qwrite(ctx context.Context, task qWriteTask) error {
 	}
 
 	for _, msg := range task.messages() {
-		if err := database.AddTaskMessages(ctx, database.TaskMessage{
+		if err := database.AddTaskMessage(context.TODO(), database.TaskMessage{
 			TaskId:  string(task.getTaskId()),
 			Message: msg,
 		}); err != nil {
@@ -190,12 +199,14 @@ func qwrite(ctx context.Context, task qWriteTask) error {
 
 func (mps *mpTaskScheduler) wWorkerRoutine() {
 	for {
+		mps.waitForGet.Done()
 		elem := mps.write_tasks.Get()
 		if elem.IsNone() {
 			zlog.Debug().Msg("w_worker Done")
 			mps.wg.Done()
 			return
 		}
+		mps.waitForGet.Add(1)
 		task := elem.Unwrap()
 		task_ctx, cancel := context.WithTimeout(mps.ctx, mps.cfg.Write_timeout)
 		if err := qwrite(task_ctx, task); err != nil {

--- a/internal/database/dynamic_endpoints.go
+++ b/internal/database/dynamic_endpoints.go
@@ -51,7 +51,7 @@ func (s *dynamicEndpoints) addDynamicEndpoint(ctx context.Context, dynamicEndpoi
 			dynamicEndpoint,
 		)
 		if mongo.IsDuplicateKeyError(err) {
-			return nil
+			return ErrDuplicateKey
 		} else if err != nil {
 			return err
 		}

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -3,3 +3,4 @@ package database
 import "errors"
 
 var ErrNoSuchPath = errors.New("no such path")
+var ErrDuplicateKey = errors.New("duplicate key")

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -6,6 +6,8 @@ const (
 	STATIC_ENDPOINT_RESPONSE_FIELD     = "response"
 	DYNAMIC_ENDPOINT_PATH_FIELD        = "path"
 	DYNAMIC_ENDPOINT_SCRIPT_NAME_FIELD = "script_name"
+	TASK_ID_FIELD                      = "task_id"
+	MESSAGE_FIELD                      = "message"
 )
 
 type StaticEndpoint struct {
@@ -16,4 +18,9 @@ type StaticEndpoint struct {
 type DynamicEndpoint struct {
 	Path       string `bson:"path" json:"path"`
 	ScriptName string `bson:"script_name" json:"script_name"`
+}
+
+type TaskMessage struct {
+	TaskId  string `bson:"task_id"`
+	Message string `bson:"message"`
 }

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -11,13 +11,13 @@ const (
 )
 
 type StaticEndpoint struct {
-	Path     string `bson:"path" json:"path"`
-	Response string `bson:"response" json:"response"`
+	Path     string `bson:"path"`
+	Response string `bson:"response"`
 }
 
 type DynamicEndpoint struct {
-	Path       string `bson:"path" json:"path"`
-	ScriptName string `bson:"script_name" json:"script_name"`
+	Path       string `bson:"path"`
+	ScriptName string `bson:"script_name"`
 }
 
 type TaskMessage struct {

--- a/internal/database/mongo.go
+++ b/internal/database/mongo.go
@@ -35,7 +35,10 @@ func (db *MongoStorage) init(ctx context.Context, client *mongo.Client, cfg *con
 		return err
 	}
 	db.taskMessages, err = createTaskMessages(ctx, client, cfg)
-	return err
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func AddStaticEndpoint(ctx context.Context, staticEndpoint StaticEndpoint) error {

--- a/internal/database/mongo.go
+++ b/internal/database/mongo.go
@@ -78,8 +78,12 @@ func ListAllDynamicEndpointPaths(ctx context.Context) ([]string, error) {
 	return db.dynamicEndpoints.listAllDynamicEndpointPaths(ctx)
 }
 
-func AddTaskMessages(ctx context.Context, taskMessages TaskMessage) error {
-	return db.taskMessages.addTaskMessages(ctx, taskMessages)
+func AddTaskMessage(ctx context.Context, taskMessage TaskMessage) error {
+	return db.taskMessages.addTaskMessage(ctx, taskMessage)
+}
+
+func GetTaskMessages(ctx context.Context, taskId string) ([]string, error) {
+	return db.taskMessages.getTaskMessages(ctx, taskId)
 }
 
 func HasEndpoint(ctx context.Context, path string) (bool, error) {

--- a/internal/database/static_endpoints.go
+++ b/internal/database/static_endpoints.go
@@ -51,7 +51,7 @@ func (s *staticEndpoints) addStaticEndpoint(ctx context.Context, staticEndpoint 
 			staticEndpoint,
 		)
 		if mongo.IsDuplicateKeyError(err) {
-			return nil
+			return ErrDuplicateKey
 		} else if err != nil {
 			return err
 		}

--- a/internal/database/task_messages.go
+++ b/internal/database/task_messages.go
@@ -1,0 +1,61 @@
+package database
+
+import (
+	"context"
+	"mock-server/internal/configs"
+	"mock-server/internal/util"
+	"sync"
+
+	"github.com/bluele/gcache"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type taskMessages struct {
+	coll  *mongo.Collection
+	cache gcache.Cache
+	mutex sync.RWMutex
+}
+
+func createTaskMessages(ctx context.Context, client *mongo.Client, cfg *configs.DatabaseConfig) (*taskMessages, error) {
+	tm := &taskMessages{}
+	err := tm.init(ctx, client, cfg)
+	return tm, err
+}
+
+func (s *taskMessages) init(ctx context.Context, client *mongo.Client, cfg *configs.DatabaseConfig) error {
+	s.coll = client.Database(DATABASE_NAME).Collection(TASK_MESSAGES_COLLECTION)
+	s.cache = gcache.New(cfg.CacheSize).Simple().LoaderFunc(func(task_id interface{}) (interface{}, error) {
+		var res TaskMessage
+		err := s.coll.FindOne(
+			ctx,
+			bson.D{primitive.E{Key: TASK_ID_FIELD, Value: task_id.(string)}},
+		).Decode(&res)
+		return res, err
+	}).Build()
+
+	indexModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: TASK_ID_FIELD, Value: 1}},
+		Options: options.Index().SetUnique(true),
+	}
+	_, err := s.coll.Indexes().CreateOne(ctx, indexModel)
+	return err
+}
+
+func (s *taskMessages) addTaskMessages(ctx context.Context, taskMessages TaskMessage) error {
+	return util.RunWithWriteLock(&s.mutex, func() error {
+		_, err := s.coll.InsertOne(
+			ctx,
+			taskMessages,
+		)
+		if mongo.IsDuplicateKeyError(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		err = s.cache.Set(taskMessages.TaskId, taskMessages)
+		return err
+	})
+}

--- a/internal/database/task_messages.go
+++ b/internal/database/task_messages.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"mock-server/internal/configs"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -26,13 +25,12 @@ func (s *taskMessages) init(ctx context.Context, client *mongo.Client, cfg *conf
 }
 
 func (s *taskMessages) addTaskMessage(ctx context.Context, taskMessage TaskMessage) error {
-	fmt.Printf("Add task message: %s\n", taskMessage)
 	_, err := s.coll.InsertOne(
 		ctx,
 		taskMessage,
 	)
 	if mongo.IsDuplicateKeyError(err) {
-		return nil
+		return ErrDuplicateKey
 	}
 	return err
 }
@@ -54,8 +52,6 @@ func (s *taskMessages) getTaskMessages(ctx context.Context, taskId string) ([]st
 	if err := cursor.All(ctx, &result); err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("getTaskMessages: taskId=%s, result=%s\n", taskId, result)
 
 	var messages = make([]string, len(result))
 	for i, taskMessage := range result {

--- a/internal/database/task_messages.go
+++ b/internal/database/task_messages.go
@@ -2,21 +2,16 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"mock-server/internal/configs"
-	"mock-server/internal/util"
-	"sync"
 
-	"github.com/bluele/gcache"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type taskMessages struct {
-	coll  *mongo.Collection
-	cache gcache.Cache
-	mutex sync.RWMutex
+	coll *mongo.Collection
 }
 
 func createTaskMessages(ctx context.Context, client *mongo.Client, cfg *configs.DatabaseConfig) (*taskMessages, error) {
@@ -27,35 +22,44 @@ func createTaskMessages(ctx context.Context, client *mongo.Client, cfg *configs.
 
 func (s *taskMessages) init(ctx context.Context, client *mongo.Client, cfg *configs.DatabaseConfig) error {
 	s.coll = client.Database(DATABASE_NAME).Collection(TASK_MESSAGES_COLLECTION)
-	s.cache = gcache.New(cfg.CacheSize).Simple().LoaderFunc(func(task_id interface{}) (interface{}, error) {
-		var res TaskMessage
-		err := s.coll.FindOne(
-			ctx,
-			bson.D{primitive.E{Key: TASK_ID_FIELD, Value: task_id.(string)}},
-		).Decode(&res)
-		return res, err
-	}).Build()
+	return nil
+}
 
-	indexModel := mongo.IndexModel{
-		Keys:    bson.D{{Key: TASK_ID_FIELD, Value: 1}},
-		Options: options.Index().SetUnique(true),
+func (s *taskMessages) addTaskMessage(ctx context.Context, taskMessage TaskMessage) error {
+	fmt.Printf("Add task message: %s\n", taskMessage)
+	_, err := s.coll.InsertOne(
+		ctx,
+		taskMessage,
+	)
+	if mongo.IsDuplicateKeyError(err) {
+		return nil
 	}
-	_, err := s.coll.Indexes().CreateOne(ctx, indexModel)
 	return err
 }
 
-func (s *taskMessages) addTaskMessages(ctx context.Context, taskMessages TaskMessage) error {
-	return util.RunWithWriteLock(&s.mutex, func() error {
-		_, err := s.coll.InsertOne(
-			ctx,
-			taskMessages,
-		)
-		if mongo.IsDuplicateKeyError(err) {
-			return nil
-		} else if err != nil {
-			return err
-		}
-		err = s.cache.Set(taskMessages.TaskId, taskMessages)
-		return err
-	})
+func (s *taskMessages) getTaskMessages(ctx context.Context, taskId string) ([]string, error) {
+	opts := options.Find()
+	opts = opts.SetSort(bson.D{{Key: "timestamp", Value: 1}})
+	opts = opts.SetProjection(bson.D{{Key: MESSAGE_FIELD, Value: 1}})
+	cursor, err := s.coll.Find(
+		ctx,
+		bson.D{{Key: TASK_ID_FIELD, Value: taskId}},
+		opts,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []TaskMessage
+	if err := cursor.All(ctx, &result); err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("getTaskMessages: taskId=%s, result=%s\n", taskId, result)
+
+	var messages = make([]string, len(result))
+	for i, taskMessage := range result {
+		messages[i] = taskMessage.Message
+	}
+	return messages, nil
 }

--- a/tests/brokers/esb_test.go
+++ b/tests/brokers/esb_test.go
@@ -6,6 +6,7 @@ import (
 	"mock-server/internal/control"
 	"mock-server/internal/database"
 	"mock-server/internal/util"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -74,15 +75,21 @@ func TestEsb(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Errorf("%s = %s\n", readTaskId1, res)
+	if !reflect.DeepEqual(res, []string{"msg1", "msg2", "msg3"}) {
+		t.Errorf("res != expected: %+q != %+q", res, []string{"msg1", "msg2", "msg3"})
+	}
 	res, err = database.GetTaskMessages(context.TODO(), string(writeTaskId))
 	if err != nil {
 		t.Error(err)
 	}
-	t.Errorf("%s = %s\n", writeTaskId, res)
+	if !reflect.DeepEqual(res, []string{"msg1", "msg2", "msg3"}) {
+		t.Errorf("res != expected: %+q != %+q", res, []string{"msg1", "msg2", "msg3"})
+	}
 	res, err = database.GetTaskMessages(context.TODO(), string(readTaskId2))
 	if err != nil {
 		t.Error(err)
 	}
-	t.Errorf("%s = %s\n", readTaskId2, res)
+	if !reflect.DeepEqual(res, []string{"msg3", "msg2", "msg1"}) {
+		t.Errorf("res != expected: %+q != %+q", res, []string{"msg3", "msg2", "msg1"})
+	}
 }

--- a/tests/brokers/esb_test.go
+++ b/tests/brokers/esb_test.go
@@ -1,8 +1,10 @@
 package brokers_test
 
 import (
+	"context"
 	"mock-server/internal/brokers"
 	"mock-server/internal/control"
+	"mock-server/internal/database"
 	"mock-server/internal/util"
 	"testing"
 	"time"
@@ -54,17 +56,33 @@ func TestEsb(t *testing.T) {
 	///////////////////////////////////////////////////////////////////////////////////////
 
 	// schedule read -- wait for args
-	pool1.NewReadTask().Schedule()
+	readTaskId1 := pool1.NewReadTask().Schedule()
 
 	time.Sleep(2 * time.Second)
 
 	// push args to first pool
-	pool1.NewWriteTask(TEST_ARGS).Schedule()
+	writeTaskId := pool1.NewWriteTask(TEST_ARGS).Schedule()
 
 	time.Sleep(2 * time.Second)
 
 	// schedule read -- pull script invocation result
-	pool2.NewReadTask().Schedule()
+	readTaskId2 := pool2.NewReadTask().Schedule()
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
+
+	res, err := database.GetTaskMessages(context.TODO(), string(readTaskId1))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Errorf("%s = %s\n", readTaskId1, res)
+	res, err = database.GetTaskMessages(context.TODO(), string(writeTaskId))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Errorf("%s = %s\n", writeTaskId, res)
+	res, err = database.GetTaskMessages(context.TODO(), string(readTaskId2))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Errorf("%s = %s\n", readTaskId2, res)
 }

--- a/tests/brokers/kafka_test.go
+++ b/tests/brokers/kafka_test.go
@@ -1,8 +1,11 @@
 package brokers_test
 
 import (
+	"context"
 	"mock-server/internal/brokers"
 	"mock-server/internal/control"
+	"mock-server/internal/database"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -35,7 +38,21 @@ func TestKafka(t *testing.T) {
 
 	handler.NewReadTask().Schedule()
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 
-	// TODO check database for read records
+	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:write")
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(writeTaskMessages, []string{"40", "41", "42"}) {
+		t.Errorf("res != expected: %s != %s", writeTaskMessages, []string{"40", "41", "42"})
+	}
+
+	readTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:read")
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(readTaskMessages, []string{"40", "41", "42"}) {
+		t.Errorf("res != expected: %s != %s", readTaskMessages, []string{"40", "41", "42"})
+	}
 }

--- a/tests/brokers/kafka_test.go
+++ b/tests/brokers/kafka_test.go
@@ -38,14 +38,14 @@ func TestKafka(t *testing.T) {
 
 	handler.NewReadTask().Schedule()
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:write")
 	if err != nil {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(writeTaskMessages, []string{"40", "41", "42"}) {
-		t.Errorf("res != expected: %s != %s", writeTaskMessages, []string{"40", "41", "42"})
+		t.Errorf("res != expected: %+q != %+q", writeTaskMessages, []string{"40", "41", "42"})
 	}
 
 	readTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:read")
@@ -53,6 +53,6 @@ func TestKafka(t *testing.T) {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(readTaskMessages, []string{"40", "41", "42"}) {
-		t.Errorf("res != expected: %s != %s", readTaskMessages, []string{"40", "41", "42"})
+		t.Errorf("res != expected: %+q != %+q", readTaskMessages, []string{"40", "41", "42"})
 	}
 }

--- a/tests/brokers/kafka_test.go
+++ b/tests/brokers/kafka_test.go
@@ -27,7 +27,7 @@ func TestKafka(t *testing.T) {
 		t.Error(err)
 	}
 
-	handler.NewWriteTask([]string{"40", "41", "42"}).Schedule()
+	writeTaskId := handler.NewWriteTask([]string{"40", "41", "42"}).Schedule()
 
 	time.Sleep(3 * time.Second)
 
@@ -36,11 +36,11 @@ func TestKafka(t *testing.T) {
 		t.Error(err)
 	}
 
-	handler.NewReadTask().Schedule()
+	readTaskId := handler.NewReadTask().Schedule()
 
 	time.Sleep(15 * time.Second)
 
-	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:write")
+	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), string(writeTaskId))
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestKafka(t *testing.T) {
 		t.Errorf("res != expected: %+q != %+q", writeTaskMessages, []string{"40", "41", "42"})
 	}
 
-	readTaskMessages, err := database.GetTaskMessages(context.TODO(), "kafka:test-pool:test-topic:read")
+	readTaskMessages, err := database.GetTaskMessages(context.TODO(), string(readTaskId))
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/brokers/rabbitmq_test.go
+++ b/tests/brokers/rabbitmq_test.go
@@ -27,7 +27,7 @@ func TestRabbitMq(t *testing.T) {
 		t.Error(err)
 	}
 
-	handler.NewReadTask().Schedule()
+	readTaskId := handler.NewReadTask().Schedule()
 
 	time.Sleep(1 * time.Second)
 
@@ -36,11 +36,11 @@ func TestRabbitMq(t *testing.T) {
 		t.Error(err)
 	}
 
-	handler.NewWriteTask([]string{"40", "41", "42"}).Schedule()
+	writeTaskId := handler.NewWriteTask([]string{"40", "41", "42"}).Schedule()
 
 	time.Sleep(10 * time.Second)
 
-	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), "rabbitmq:test-pool:test-mock-queue:write")
+	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), string(writeTaskId))
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestRabbitMq(t *testing.T) {
 		t.Errorf("res != expected: %+q != %+q", writeTaskMessages, []string{"40", "41", "42"})
 	}
 
-	readTaskMessages, err := database.GetTaskMessages(context.TODO(), "rabbitmq:test-pool:test-mock-queue:read")
+	readTaskMessages, err := database.GetTaskMessages(context.TODO(), string(readTaskId))
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/brokers/rabbitmq_test.go
+++ b/tests/brokers/rabbitmq_test.go
@@ -38,7 +38,7 @@ func TestRabbitMq(t *testing.T) {
 
 	handler.NewWriteTask([]string{"40", "41", "42"}).Schedule()
 
-	brokers.MPTaskScheduler.WaitIdle()
+	time.Sleep(10 * time.Second)
 
 	writeTaskMessages, err := database.GetTaskMessages(context.TODO(), "rabbitmq:test-pool:test-mock-queue:write")
 	if err != nil {

--- a/tests/brokers/rabbitmq_test.go
+++ b/tests/brokers/rabbitmq_test.go
@@ -45,7 +45,7 @@ func TestRabbitMq(t *testing.T) {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(writeTaskMessages, []string{"40", "41", "42"}) {
-		t.Errorf("res != expected: %s != %s", writeTaskMessages, []string{"40", "41", "42"})
+		t.Errorf("res != expected: %+q != %+q", writeTaskMessages, []string{"40", "41", "42"})
 	}
 
 	readTaskMessages, err := database.GetTaskMessages(context.TODO(), "rabbitmq:test-pool:test-mock-queue:read")
@@ -53,6 +53,6 @@ func TestRabbitMq(t *testing.T) {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(readTaskMessages, []string{"40", "41", "42"}) {
-		t.Errorf("res != expected: %s != %s", readTaskMessages, []string{"40", "41", "42"})
+		t.Errorf("res != expected: %+q != %+q", readTaskMessages, []string{"40", "41", "42"})
 	}
 }

--- a/tests/database/endpoints_test.go
+++ b/tests/database/endpoints_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"context"
 	"math/rand"
 	"mock-server/internal/configs"
 	"mock-server/internal/control"
@@ -47,19 +48,19 @@ func TestStaticEndpoints(t *testing.T) {
 			endpoints = append(endpoints, database.StaticEndpoint{Path: "/five", Response: "five"})
 
 			for _, endpoint := range endpoints {
-				if err := database.AddStaticEndpoint(endpoint); err != nil {
+				if err := database.AddStaticEndpoint(context.TODO(), endpoint); err != nil {
 					t.Errorf("AddStaticEndpoint return err: %s", err.Error())
 				}
 			}
 
 			// Check that we store only unique elems
 			for _, endpoint := range endpoints {
-				if err := database.AddStaticEndpoint(endpoint); err != nil {
+				if err := database.AddStaticEndpoint(context.TODO(), endpoint); err != nil {
 					t.Errorf("AddStaticEndpoint return err: %s", err.Error())
 				}
 			}
 
-			res, err := database.ListAllStaticEndpointPaths()
+			res, err := database.ListAllStaticEndpointPaths(context.TODO())
 			if err != nil {
 				t.Errorf("ListAllStaticEndpointPaths return err: %s", err.Error())
 			}
@@ -69,7 +70,7 @@ func TestStaticEndpoints(t *testing.T) {
 			}
 
 			for _, endpoint := range endpoints {
-				res, err := database.GetStaticEndpointResponse(endpoint.Path)
+				res, err := database.GetStaticEndpointResponse(context.TODO(), endpoint.Path)
 				if err != nil {
 					t.Errorf("GetStaticEndpointResponse return err: %s", err.Error())
 				}
@@ -80,11 +81,11 @@ func TestStaticEndpoints(t *testing.T) {
 
 			for i := 0; i < 5; i++ {
 				id := rand.Int() % (5 - i)
-				if err := database.RemoveStaticEndpoint(endpoints[id].Path); err != nil {
+				if err := database.RemoveStaticEndpoint(context.TODO(), endpoints[id].Path); err != nil {
 					t.Errorf("RemoveStaticEndpoint return err: %s", err.Error())
 				}
 				endpoints = append(endpoints[:id], endpoints[id+1:]...)
-				res, err := database.ListAllStaticEndpointPaths()
+				res, err := database.ListAllStaticEndpointPaths(context.TODO())
 				if err != nil {
 					t.Errorf("ListAllStaticEndpoints return err: %s", err.Error())
 				}
@@ -94,19 +95,19 @@ func TestStaticEndpoints(t *testing.T) {
 				}
 			}
 
-			if err := database.AddStaticEndpoint(database.StaticEndpoint{
+			if err := database.AddStaticEndpoint(context.TODO(), database.StaticEndpoint{
 				Path:     "/path",
 				Response: "one",
 			}); err != nil {
 				t.Errorf("AddStaticEndpoint return err: %s", err.Error())
 			}
-			if err := database.AddStaticEndpoint(database.StaticEndpoint{
+			if err := database.AddStaticEndpoint(context.TODO(), database.StaticEndpoint{
 				Path:     "/path",
 				Response: "two",
 			}); err != nil {
 				t.Errorf("AddStaticEndpoint return err: %s", err.Error())
 			}
-			response, err := database.GetStaticEndpointResponse("/path")
+			response, err := database.GetStaticEndpointResponse(context.TODO(), "/path")
 			if err != nil {
 				t.Errorf("GetStaticEndpointResponse return err: %s", err.Error())
 			}
@@ -114,13 +115,13 @@ func TestStaticEndpoints(t *testing.T) {
 				t.Errorf("response != expected: %s != one", response)
 			}
 
-			if err = database.UpdateStaticEndpoint(database.StaticEndpoint{
+			if err = database.UpdateStaticEndpoint(context.TODO(), database.StaticEndpoint{
 				Path:     "/path",
 				Response: "two",
 			}); err != nil {
 				t.Errorf("UpdateStaticEndpoint return err: %s", err.Error())
 			}
-			response, err = database.GetStaticEndpointResponse("/path")
+			response, err = database.GetStaticEndpointResponse(context.TODO(), "/path")
 			if err != nil {
 				t.Errorf("GetStaticEndpointResponse return err: %s", err.Error())
 			}
@@ -161,18 +162,18 @@ func TestDynamicEndpoints(t *testing.T) {
 			endpoints = append(endpoints, database.DynamicEndpoint{Path: "/five", ScriptName: "five"})
 
 			for _, endpoint := range endpoints {
-				if err := database.AddDynamicEndpoint(endpoint); err != nil {
+				if err := database.AddDynamicEndpoint(context.TODO(), endpoint); err != nil {
 					t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
 				}
 			}
 
 			for _, endpoint := range endpoints {
-				if err := database.AddDynamicEndpoint(endpoint); err != nil {
+				if err := database.AddDynamicEndpoint(context.TODO(), endpoint); err != nil {
 					t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
 				}
 			}
 
-			res, err := database.ListAllDynamicEndpointPaths()
+			res, err := database.ListAllDynamicEndpointPaths(context.TODO())
 			if err != nil {
 				t.Errorf("ListAllDynamicEndpointPaths return err: %s", err.Error())
 			}
@@ -182,7 +183,7 @@ func TestDynamicEndpoints(t *testing.T) {
 			}
 
 			for _, endpoint := range endpoints {
-				res, err := database.GetDynamicEndpointScriptName(endpoint.Path)
+				res, err := database.GetDynamicEndpointScriptName(context.TODO(), endpoint.Path)
 				if err != nil {
 					t.Errorf("GetDynamicEndpointScriptName return err: %s", err.Error())
 				}
@@ -193,11 +194,11 @@ func TestDynamicEndpoints(t *testing.T) {
 
 			for i := 0; i < 5; i++ {
 				id := rand.Int() % (5 - i)
-				if err := database.RemoveDynamicEndpoint(endpoints[id].Path); err != nil {
+				if err := database.RemoveDynamicEndpoint(context.TODO(), endpoints[id].Path); err != nil {
 					t.Errorf("RemoveDynamicEndpoint return err: %s", err.Error())
 				}
 				endpoints = append(endpoints[:id], endpoints[id+1:]...)
-				res, err := database.ListAllDynamicEndpointPaths()
+				res, err := database.ListAllDynamicEndpointPaths(context.TODO())
 				if err != nil {
 					t.Errorf("ListAllDynamicEndpointPaths return err: %s", err.Error())
 				}
@@ -207,19 +208,19 @@ func TestDynamicEndpoints(t *testing.T) {
 				}
 			}
 
-			if err := database.AddDynamicEndpoint(database.DynamicEndpoint{
+			if err := database.AddDynamicEndpoint(context.TODO(), database.DynamicEndpoint{
 				Path:       "/path",
 				ScriptName: "one",
 			}); err != nil {
 				t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
 			}
-			if err := database.AddDynamicEndpoint(database.DynamicEndpoint{
+			if err := database.AddDynamicEndpoint(context.TODO(), database.DynamicEndpoint{
 				Path:       "/path",
 				ScriptName: "two",
 			}); err != nil {
 				t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
 			}
-			response, err := database.GetDynamicEndpointScriptName("/path")
+			response, err := database.GetDynamicEndpointScriptName(context.TODO(), "/path")
 			if err != nil {
 				t.Errorf("GetDynamicEndpointScriptName return err: %s", err.Error())
 			}
@@ -227,13 +228,13 @@ func TestDynamicEndpoints(t *testing.T) {
 				t.Errorf("response != expected: %s != one", response)
 			}
 
-			if err = database.UpdateDynamicEndpoint(database.DynamicEndpoint{
+			if err = database.UpdateDynamicEndpoint(context.TODO(), database.DynamicEndpoint{
 				Path:       "/path",
 				ScriptName: "two",
 			}); err != nil {
 				t.Errorf("UpdateDynamicEndpoint return err: %s", err.Error())
 			}
-			response, err = database.GetDynamicEndpointScriptName("/path")
+			response, err = database.GetDynamicEndpointScriptName(context.TODO(), "/path")
 			if err != nil {
 				t.Errorf("GetDynamicEndpointScriptName return err: %s", err.Error())
 			}

--- a/tests/database/endpoints_test.go
+++ b/tests/database/endpoints_test.go
@@ -91,7 +91,7 @@ func TestStaticEndpoints(t *testing.T) {
 				}
 
 				if !compareStaticEndpointPaths(res, endpoints) {
-					t.Errorf("res != expected: %s != %s", res, endpoints)
+					t.Errorf("res != expected: %+q != %+q", res, endpoints)
 				}
 			}
 
@@ -204,7 +204,7 @@ func TestDynamicEndpoints(t *testing.T) {
 				}
 
 				if !compareDynamicEndpointPaths(res, endpoints) {
-					t.Errorf("res != expected: %s != %s", res, endpoints)
+					t.Errorf("res != expected: %+q != %+q", res, endpoints)
 				}
 			}
 

--- a/tests/database/endpoints_test.go
+++ b/tests/database/endpoints_test.go
@@ -55,8 +55,8 @@ func TestStaticEndpoints(t *testing.T) {
 
 			// Check that we store only unique elems
 			for _, endpoint := range endpoints {
-				if err := database.AddStaticEndpoint(context.TODO(), endpoint); err != nil {
-					t.Errorf("AddStaticEndpoint return err: %s", err.Error())
+				if err := database.AddStaticEndpoint(context.TODO(), endpoint); err != database.ErrDuplicateKey {
+					t.Errorf("AddStaticEndpoint shoud return ErrDuplicateKey")
 				}
 			}
 
@@ -104,8 +104,8 @@ func TestStaticEndpoints(t *testing.T) {
 			if err := database.AddStaticEndpoint(context.TODO(), database.StaticEndpoint{
 				Path:     "/path",
 				Response: "two",
-			}); err != nil {
-				t.Errorf("AddStaticEndpoint return err: %s", err.Error())
+			}); err != database.ErrDuplicateKey {
+				t.Errorf("AddStaticEndpoint should return ErrDuplicateKey")
 			}
 			response, err := database.GetStaticEndpointResponse(context.TODO(), "/path")
 			if err != nil {
@@ -168,8 +168,8 @@ func TestDynamicEndpoints(t *testing.T) {
 			}
 
 			for _, endpoint := range endpoints {
-				if err := database.AddDynamicEndpoint(context.TODO(), endpoint); err != nil {
-					t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
+				if err := database.AddDynamicEndpoint(context.TODO(), endpoint); err != database.ErrDuplicateKey {
+					t.Error("AddDynamicEndpoint should return ErrDuplicateKey")
 				}
 			}
 
@@ -217,8 +217,8 @@ func TestDynamicEndpoints(t *testing.T) {
 			if err := database.AddDynamicEndpoint(context.TODO(), database.DynamicEndpoint{
 				Path:       "/path",
 				ScriptName: "two",
-			}); err != nil {
-				t.Errorf("AddDynamicEndpoint return err: %s", err.Error())
+			}); err != database.ErrDuplicateKey {
+				t.Errorf("AddDynamicEndpoint should return ErrDuplicateKey: %s", err.Error())
 			}
 			response, err := database.GetDynamicEndpointScriptName(context.TODO(), "/path")
 			if err != nil {

--- a/tests/database/task_messages_test.go
+++ b/tests/database/task_messages_test.go
@@ -1,0 +1,53 @@
+package database_test
+
+import (
+	"context"
+	"mock-server/internal/control"
+	"mock-server/internal/database"
+	"reflect"
+	"testing"
+)
+
+func TestTaskMessages(t *testing.T) {
+	t.Setenv("CONFIG_PATH", "/configs/test_database_config.yaml")
+	control.Components.Start()
+	defer control.Components.Stop()
+
+	expectedTask1Messages := []database.TaskMessage{
+		{TaskId: "task1", Message: "one"},
+		{TaskId: "task1", Message: "two"},
+	}
+	expectedTask2Messages := []database.TaskMessage{
+		{TaskId: "task2", Message: "three"},
+		{TaskId: "task2", Message: "four"},
+		{TaskId: "task2", Message: "five"},
+	}
+
+	for _, msg := range expectedTask1Messages {
+		if err := database.AddTaskMessage(context.TODO(), msg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	for _, msg := range expectedTask2Messages {
+		if err := database.AddTaskMessage(context.TODO(), msg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	actualTask1Messages, err := database.GetTaskMessages(context.TODO(), "task1")
+	if err != nil {
+		t.Error(err)
+	}
+	if reflect.DeepEqual(expectedTask1Messages, actualTask1Messages) {
+		t.Errorf("res != expected: %+q != %+q", actualTask1Messages, expectedTask1Messages)
+	}
+
+	actualTask2Messages, err := database.GetTaskMessages(context.TODO(), "task2")
+	if err != nil {
+		t.Error(err)
+	}
+	if reflect.DeepEqual(expectedTask2Messages, actualTask2Messages) {
+		t.Errorf("res != expected: %+q != %+q", actualTask2Messages, expectedTask2Messages)
+	}
+}


### PR DESCRIPTION
Во-первых, понял, что контекстом мы как-то неправильно пользовались) Его не надо в структуре хранить точно, получать нужно из запросов. Хз, как шедулер правда надо поменять под это) У себя в базе сделал так, чтобы он передавался через публичные методы.
Во-вторых, у меня не получилось сделать нормально тесты с rabbitmq_test, пришлось добавить метод у шедулера, который ждет пока все воркеры не перейдут в режим ожидания. Я хз, насколько плохо такое добавлять у шедулеры (конкарты очень очень давно не смотрел), но зато теперь тесты работают) Если кажется. что добавление WaitIdle - это плохой дизайн: пожалуйста объясните почему и как сделать иначе.

Как только придем к консенсусу по изменениям добавлю сюда же тесты на новую коллекцию и обновлю тесты для кафки.